### PR TITLE
FFWS-95 Add other files to grant page

### DIFF
--- a/src/fleming-theme/custom-post-types/types/grants.json
+++ b/src/fleming-theme/custom-post-types/types/grants.json
@@ -272,6 +272,60 @@
                 "mime_types": ""
             },
             {
+                "key": "field_5ba0fad3164d2",
+                "label": "Other files",
+                "name": "other_files",
+                "type": "repeater",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "collapsed": "",
+                "min": 0,
+                "max": 0,
+                "layout": "table",
+                "button_label": "Add file",
+                "sub_fields": [
+                    {
+                        "key": "field_5b6165ccf2f5e",
+                        "label": "Description",
+                        "name": "title",
+                        "type": "text",
+                        "instructions": "",
+                        "required": 1,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        }
+                    },
+                    {
+                        "key": "field_5b14d3f68fbda",
+                        "label": "File",
+                        "name": "file",
+                        "type": "file",
+                        "instructions": "",
+                        "required": 1,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "return_format": "array",
+                        "library": "all",
+                        "min_size": "",
+                        "max_size": "",
+                        "mime_types": ""
+                    }
+                ]
+            },
+            {
                 "key": "field_5b0697866ae1f",
                 "label": "Funds Available",
                 "name": "funds_available",

--- a/src/fleming-theme/custom-post-types/types/grants.json
+++ b/src/fleming-theme/custom-post-types/types/grants.json
@@ -272,7 +272,7 @@
                 "mime_types": ""
             },
             {
-                "key": "field_5ba0fad3164d2",
+                "key": "field_e12ec000ade54",
                 "label": "Other files",
                 "name": "other_files",
                 "type": "repeater",
@@ -291,7 +291,7 @@
                 "button_label": "Add file",
                 "sub_fields": [
                     {
-                        "key": "field_5b6165ccf2f5e",
+                        "key": "field_56c4249310434",
                         "label": "Description",
                         "name": "title",
                         "type": "text",
@@ -305,7 +305,7 @@
                         }
                     },
                     {
-                        "key": "field_5b14d3f68fbda",
+                        "key": "field_11dd57c037884",
                         "label": "File",
                         "name": "file",
                         "type": "file",

--- a/src/fleming-theme/templates/common-scss/_cards.scss
+++ b/src/fleming-theme/templates/common-scss/_cards.scss
@@ -147,6 +147,7 @@
     border-color: map-get($colourConfig, intense);
     background: map-get($colourConfig, intense);
     color: #fff;
+    width: 100%;
 
     .button {
       background: map-get($colourConfig, subtle);

--- a/src/fleming-theme/templates/page-types/single-grants.html
+++ b/src/fleming-theme/templates/page-types/single-grants.html
@@ -73,6 +73,16 @@
         <button class="button" style="width: 100%; height: auto; box-sizing: border-box;">Download RFP</button>
       </a>
     {% endif %}
+    {% for file in fields.other_files.value %}
+        <div class="card {{ colour_scheme }} aside-card">
+          <div class="content">
+            <p>{{ file.title }}</p>
+            <a href={{ file.file.url }}>
+              <button class="button">Download &darr;</button>
+            </a>
+          </div>
+        </div>
+      {% endfor %}
   {% endblock %}
 {% endembed %}
 

--- a/src/fleming-theme/templates/page-types/single-grants.html
+++ b/src/fleming-theme/templates/page-types/single-grants.html
@@ -74,15 +74,15 @@
       </a>
     {% endif %}
     {% for file in fields.other_files.value %}
-        <div class="card {{ colour_scheme }} aside-card">
-          <div class="content">
-            <p>{{ file.title }}</p>
-            <a href={{ file.file.url }}>
-              <button class="button">Download &darr;</button>
-            </a>
-          </div>
+      <div class="card {{ colour_scheme }} aside-card">
+        <div class="content">
+          <p>{{ file.title }}</p>
+          <a href={{ file.file.url }}>
+            <button class="button">Download &darr;</button>
+          </a>
         </div>
-      {% endfor %}
+      </div>
+    {% endfor %}
   {% endblock %}
 {% endembed %}
 


### PR DESCRIPTION
Ticket [FFWS-95](https://softwiretech.atlassian.net/browse/FFWS-95)

Pull request rather than Crucible at the request of Sarah since I've not been added to Crucible for this project by Helpdesk.

Copied the functionality of the Other Files field on the country pages to the grants page so that they appear below the RPF. The styling is the same as the cards from the countries page (fixed a bug where if the text is too short the card isn't the full width of the aside element) and follows the same resizing/moving as those cards.

Mobile:
![GrantPageMobile](https://user-images.githubusercontent.com/59561751/111616414-c2283500-87d9-11eb-9fc8-c170a1ba7bba.png)

Tablet:
![GrantPageTablet](https://user-images.githubusercontent.com/59561751/111616418-c2c0cb80-87d9-11eb-9fea-f4f98150fe4c.png)

Desktop:
![GrantPageDesktop](https://user-images.githubusercontent.com/59561751/111616419-c2c0cb80-87d9-11eb-9228-a9590111f93b.png)

Admin site:
![GrantPageAdminSide](https://user-images.githubusercontent.com/59561751/111616421-c3596200-87d9-11eb-959a-781a0b960b38.png)
